### PR TITLE
add consumer

### DIFF
--- a/src/OrderFlow.PaymentService/OrderFlow.PaymentService.csproj
+++ b/src/OrderFlow.PaymentService/OrderFlow.PaymentService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.14.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
   </ItemGroup>
 

--- a/src/OrderFlow.PaymentService/Worker.cs
+++ b/src/OrderFlow.PaymentService/Worker.cs
@@ -1,16 +1,99 @@
+using Confluent.Kafka;
+using OrderFlow.Contracts;
+using System.Text.Json;
+
 namespace OrderFlow.PaymentService;
 
-public class Worker(ILogger<Worker> logger) : BackgroundService
+public class Worker(
+    ILogger<Worker> logger,
+    IConfiguration configuration) : BackgroundService
 {
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        var bootstrapServers = configuration["Kafka:BootstrapServers"];
+        var topic = configuration["Kafka:OrderCreatedTopic"];
+        var groupId = configuration["Kafka:GroupId"];
+
+        if (string.IsNullOrWhiteSpace(bootstrapServers))
         {
-            if (logger.IsEnabled(LogLevel.Information))
-            {
-                logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-            }
-            await Task.Delay(1000, stoppingToken);
+            throw new InvalidOperationException("Kafka:BootstrapServers is not configured.");
         }
+
+        if (string.IsNullOrWhiteSpace(topic))
+        {
+            throw new InvalidOperationException("Kafka:OrderCreatedTopic is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(groupId))
+        {
+            throw new InvalidOperationException("Kafka:GroupId is not configured.");
+        }
+
+        var consumerConfig = new ConsumerConfig
+        {
+            BootstrapServers = bootstrapServers,
+            GroupId = groupId,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
+
+        consumer.Subscribe(topic);
+
+        logger.LogInformation(
+            "Kafka consumer started. Topic: {Topic}, GroupId: {GroupId}",
+            topic,
+            groupId);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var consumeResult = consumer.Consume(stoppingToken);
+
+                var orderCreatedEvent = JsonSerializer.Deserialize<OrderCreatedEvent>(
+                    consumeResult.Message.Value);
+
+                if (orderCreatedEvent is null)
+                {
+                    logger.LogWarning(
+                        "Received empty or invalid message. Topic: {Topic}, Partition: {Partition}, Offset: {Offset}",
+                        consumeResult.Topic,
+                        consumeResult.Partition.Value,
+                        consumeResult.Offset.Value);
+
+                    continue;
+                }
+
+
+
+                logger.LogInformation(
+                   "Order created event received. EventId: {EventId}, OrderId: {OrderId}, UserId: {UserId}, Amount: {Amount}, Currency: {Currency}, Partition: {Partition}, Offset: {Offset}",
+                   orderCreatedEvent.EventId,
+                   orderCreatedEvent.OrderId,
+                   orderCreatedEvent.UserId,
+                   orderCreatedEvent.Amount,
+                   orderCreatedEvent.Currency,
+                   consumeResult.Partition.Value,
+                   consumeResult.Offset.Value);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Kafka consumer is stopping due to cancellation.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while consuming messages from Kafka.");
+        }
+        finally
+        {
+            consumer.Close();
+            logger.LogInformation("Kafka consumer has been closed.");
+        }
+        return Task.CompletedTask;
     }
 }
+

--- a/src/OrderFlow.PaymentService/Worker.cs
+++ b/src/OrderFlow.PaymentService/Worker.cs
@@ -11,7 +11,6 @@ public class Worker(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-
         await Task.Yield();
 
         var bootstrapServers = configuration["Kafka:BootstrapServers"];

--- a/src/OrderFlow.PaymentService/Worker.cs
+++ b/src/OrderFlow.PaymentService/Worker.cs
@@ -9,8 +9,11 @@ public class Worker(
     IConfiguration configuration) : BackgroundService
 {
 
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+
+        await Task.Yield();
+
         var bootstrapServers = configuration["Kafka:BootstrapServers"];
         var topic = configuration["Kafka:OrderCreatedTopic"];
         var groupId = configuration["Kafka:GroupId"];
@@ -51,10 +54,43 @@ public class Worker(
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                var consumeResult = consumer.Consume(stoppingToken);
 
-                var orderCreatedEvent = JsonSerializer.Deserialize<OrderCreatedEvent>(
-                    consumeResult.Message.Value);
+                ConsumeResult<string, string> consumeResult;
+
+                try
+                {
+                    consumeResult = consumer.Consume(stoppingToken);
+                }
+                catch (ConsumeException ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Kafka consume error. Reason: {Reason}",
+                        ex.Error.Reason);
+
+                    continue;
+                }
+
+                OrderCreatedEvent? orderCreatedEvent;
+
+                try
+                {
+                    orderCreatedEvent = JsonSerializer.Deserialize<OrderCreatedEvent>(
+                        consumeResult.Message.Value);
+                }
+                catch (JsonException ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Failed to deserialize Kafka message. Topic: {Topic}, Partition: {Partition}, Offset: {Offset}, Value: {Value}",
+                        consumeResult.Topic,
+                        consumeResult.Partition.Value,
+                        consumeResult.Offset.Value,
+                        consumeResult.Message.Value);
+
+                    continue;
+                }
+
 
                 if (orderCreatedEvent is null)
                 {
@@ -93,7 +129,6 @@ public class Worker(
             consumer.Close();
             logger.LogInformation("Kafka consumer has been closed.");
         }
-        return Task.CompletedTask;
     }
 }
 

--- a/src/OrderFlow.PaymentService/Worker.cs
+++ b/src/OrderFlow.PaymentService/Worker.cs
@@ -122,6 +122,7 @@ public class Worker(
         catch (Exception ex)
         {
             logger.LogError(ex, "An error occurred while consuming messages from Kafka.");
+            throw;
         }
         finally
         {

--- a/src/OrderFlow.PaymentService/appsettings.json
+++ b/src/OrderFlow.PaymentService/appsettings.json
@@ -6,6 +6,8 @@
     }
   },
   "Kafka": {
-    "BootstrapServers": "localhost:9092"
+    "BootstrapServers": "localhost:9092",
+    "OrderCreatedTopic": "order.created",
+    "GroupId": "payment-service"
   }
 }


### PR DESCRIPTION
## Что сделано

- Добавлен Confluent.Kafka в PaymentService
- Добавлены настройки Kafka consumer в appsettings.json
- PaymentService подписывается на topic order.created
- Настроена consumer group payment-service
- Полученные сообщения десериализуются в OrderCreatedEvent
- В логах выводятся EventId, OrderId, UserId, Amount, Currency, Partition и Offset

## Проверка
```bash
docker compose up -d
dotnet run --project src/OrderFlow.PaymentService
dotnet run --project src/OrderFlow.OrderService
curl -X POST http://localhost:5079/orders/test-event